### PR TITLE
Mac OS X では libcallnr() を用いたライブラリ関数の呼び出しが失敗する

### DIFF
--- a/autoload/qfixmemo.vim
+++ b/autoload/qfixmemo.vim
@@ -810,7 +810,9 @@ function! qfixmemo#Init(...)
     call howm_schedule#Init()
   endif
   call qfixmemo#LoadKeyword()
-  if has('unix') && !has('win32unix')
+  if has('macunix')
+    silent! call libcallnr("libc.dylib", "srand", localtime())
+  elseif has('unix') && !has('win32unix')
     silent! call libcallnr("", "srand", localtime())
   else
     silent! call libcallnr("msvcrt.dll", "srand", localtime())
@@ -1678,7 +1680,9 @@ function! s:randomList(list, len, dir)
 endfunction
 
 function! s:random(range)
-  if has('unix') && !has('win32unix')
+  if has('macunix')
+    let r = libcallnr("libc.dylib", "rand", -1) % a:range
+  elseif has('unix') && !has('win32unix')
     let r = libcallnr("", "rand", -1) % a:range
   else
     let r = libcallnr("msvcrt.dll", "rand", -1) % a:range


### PR DESCRIPTION
### 問題

乱数を取得するために _libcallnr()_ を用いてライブラリ関数を呼び出していますが、Mac OS X ではライブラリ関数の呼び出しに失敗します。
### 環境

```
OS:  Mac OS X 10.7.2 Lion
Vim: macvim-kaoriya 7.3.390
```
### エラーメッセージ

```
function qfixmemo#OpenMenu..QFixHowmOpenMenu..qfixmemo#RandomWalk..<SNR>106_randomList..<SNR>106_random の処理中にエラーが検出されました:
行    3:
dlerror = "dlopen(, 5): no suitable image found.  Did find:^@^I/usr/local/lib/: not a file^@^I/usr/lib/: not a file"
E364: "rand"() のライブラリ呼出に失敗しました
dlerror = "dlopen(, 5): no suitable image found.  Did find:^@^I/usr/local/lib/: not a file^@^I/usr/lib/: not a file"
E364: "rand"() のライブラリ呼出に失敗しました
```
### 解決案

現在は (win32unixを除き)  unix feature が適用されている場合、_libcallnr()_ の第一引数として空文字列を渡していますが、Mac OS X の場合は _libc.dylib_ を渡すことで、ライブラリ関数を呼び出せるように修正しました。

もっと良い解決案がありそうなのですが、ひとまず簡単な修正として pull request も合わせて申請を行いました。
お手数をおかけしますが、よろしくお願いします。 
