### PR TITLE
`se rnu` してると、カレンダー表示時に行番号が出る

### DIFF
--- a/autoload/howm_calendar.vim
+++ b/autoload/howm_calendar.vim
@@ -264,6 +264,7 @@ function! QFixMemoCalendar(dircmd, file, cnt, ...)
   setlocal nolist
   setlocal nowrap
   setlocal nonumber
+  setlocal norelativenumber
   setlocal nomodifiable
   let &winfixheight = g:submenu_calendar_winfixheight
   let &winfixwidth  = g:submenu_calendar_winfixwidth


### PR DESCRIPTION
表題の通りです。`set norelativenumber` を付け加えただけです。
