### PR TITLE
QFixHowm互換有効時にQFixMemoChEnv()が無効化される

### DIFF
--- a/misc/qfixmemo-chenv.vim
+++ b/misc/qfixmemo-chenv.vim
@@ -167,6 +167,11 @@ function! QFixMemoChEnv(dir, fname, title)
     let g:qfixmemo_filename = '%Y/%m/%Y-%m-%d-%H%M%S'
   endif
 
+  " QFixHowm 互換オプションの設定
+  if exists('QFixHowm_Convert') && QFixHowm_Convert != 0
+    let g:howm_dir = g:qfixmemo_dir
+  endif
+
   echo "qfixmemo_dir = ".g:qfixmemo_dir
 
   " スクリプト作成


### PR DESCRIPTION
# 問題

QFixHowm互換オプションコンバート有効時（QFixHowm_Convert != 0）には、QFixHowmSetup()によってg:howm_dirの内容がg:qfixmemo_dirに設定されされますが、
QFixMemoChEnv()はg:qfixmemo_dirしか設定していないので、
QFixHowmSetup()が呼ばれると、QFixMemoChEnv()が設定したg:qfixmemo_dirが設定前に戻ってしまいます。
# 解決案

オプションコンバート有効時には、QFixMemoChEnv()でg:qfixmemo_dirだけでなくg:howm_dirにも設定するようにしました。

そもそもQFixMemoChEnv()を使うような場合は、QFixHowm互換を有効にすべきではないということなのでしょうか。
よろしくお願いいたします。
