### PR TITLE
Fix up and down cycle

### DIFF
--- a/autoload/howm_schedule.vim
+++ b/autoload/howm_schedule.vim
@@ -1604,14 +1604,13 @@ function! s:QFixHowmGetPriority(priority, cmd, opt, today)
   elseif cmd =~ '^\~'
     "# 指定日から, 浮き沈みをくりかえす
     "# 指定日までは底に潜伏
-    let cycle = opt / 2
     if priority <= today
       let term = priority - today
-      let len = term % cycle
+      let len = term % opt
       if (term / opt) % 2
-        let priority = today - len
+        let priority = today - (len + opt)
       else
-        let priority = today - cycle + len
+        let priority = today + len
       endif
     else
       let priority = 0

--- a/autoload/howm_schedule.vim
+++ b/autoload/howm_schedule.vim
@@ -1605,10 +1605,11 @@ function! s:QFixHowmGetPriority(priority, cmd, opt, today)
     "# 指定日から, 浮き沈みをくりかえす
     "# 指定日までは底に潜伏
     if priority <= today
+      let cycle = opt / 2
       let term = priority - today
-      let len = term % opt
-      if (term / opt) % 2
-        let priority = today - (len + opt)
+      let len = term % cycle
+      if (term / cycle) % 2
+        let priority = today - (len + cycle)
       else
         let priority = today + len
       endif


### PR DESCRIPTION
浮沈TODOの挙動が怪しい気がします。
具体的には、設定値が10の場合、優先度が以下のように推移します。
```
 -5
 -6
 -7
 -8
 -9
 -5
 -6
 -7
 -8
 -9
 0
 1
 2
 3
 4
 0
 1
 2
 3
 4
```

これだと、最初の設定値日後には0に戻りますが、次に0に戻るタイミングがおかしいです。
設定値10の場合は10日後、15日後、30日後、となります。

また、優先度が0より大きくなるのも浮沈TODOの目的から考えると違和感があります。

正しい仕様がわからないため、とりあえず以下のような推移になるよう修正してみました。

```
0
-1
-2
-3
-4
-5
-4
-3
-2
-1
0
```