### PR TITLE
fixed unscoped variable "count", for neovim 0.2.2

### DIFF
--- a/autoload/howm_calendar.vim
+++ b/autoload/howm_calendar.vim
@@ -344,14 +344,14 @@ function! QFixMemoCalendar(dircmd, file, cnt, ...)
 endfunction
 
 function! s:CR(...)
-  if count == 0
+  if v:count == 0
     let key = expand('<cWORD>')
     if key !~ '[<>./]\|\(^[A-Z][a-z]\{2}$\)'
       let key = expand('<cword>')
     endif
     let key =  a:0 ? a:1 :key
-  elseif count < 32
-    let key = count
+  elseif v:count < 32
+    let key = v:count
   else
     echo 'QFixCalendar : invalid argument.'
     return
@@ -450,7 +450,7 @@ function! s:CR(...)
 endfunction
 
 function! s:calmovecmd(cmd)
-  let c = count > 0 ? count : 1
+  let c = v:count > 0 ? v:count : 1
   for n in range(c)
     call search('\([*] \?\)\?[0-9<.>]\+[*]\?', a:cmd)
     while expand('<cWORD>') =~ '\d\{4}/\d\{2}' " && expand('<cword>') =~ '^\d\{2}$'

--- a/autoload/howm_menu.vim
+++ b/autoload/howm_menu.vim
@@ -307,8 +307,8 @@ endfunction
 function! QFixHowmOpenMenu(...)
   let prevPath = s:escape(getcwd(), ' ')
   call qfixmemo#Init()
-  if count > 0
-    let g:QFixHowm_ShowScheduleMenu = count
+  if v:count > 0
+    let g:QFixHowm_ShowScheduleMenu = v:count
   endif
   redraw | echo 'QFixHowm : Open menu...'
   if exists('*QFixWinnr')
@@ -593,8 +593,8 @@ endfunction
 
 function! s:HowmMenuCR() range
   let save_cursor = getpos('.')
-  if count
-    call cursor(count, 1)
+  if v:count
+    call cursor(v:count, 1)
   endif
   call search('[^\s]', 'cb', line('.'))
   call search('[^\s]', 'cw', line('.'))

--- a/autoload/howm_schedule.vim
+++ b/autoload/howm_schedule.vim
@@ -421,18 +421,18 @@ endfunction
 
 let s:reminder_cache = 0
 function! QFixHowmListReminderCache(mode)
-  if count > 0
+  if v:count > 0
     if a:mode =~ 'schedule'
-      let g:QFixHowm_ShowSchedule = count
+      let g:QFixHowm_ShowSchedule = v:count
     elseif a:mode =~ 'todo'
-      let g:QFixHowmListReminderTodo = count
+      let g:QFixHowmListReminderTodo = v:count
     endif
   endif
   if exists('*QFixHowmInit') && QFixHowmInit()
     return
   endif
   exe 'let lt = localtime() - s:LT_' . a:mode
-  if count
+  if v:count
     " let lt = g:QFixHowm_ListReminderCacheTime + 1
   endif
   if g:QFixHowm_ListReminderCacheTime > 0 && lt < g:QFixHowm_ListReminderCacheTime
@@ -445,11 +445,11 @@ function! QFixHowmListReminderCache(mode)
 endfunction
 
 function! QFixHowmListReminder(mode)
-  if count > 0
+  if v:count > 0
     if a:mode =~ 'schedule'
-      let g:QFixHowm_ShowSchedule = count
+      let g:QFixHowm_ShowSchedule = v:count
     elseif a:mode =~ 'todo'
-      let g:QFixHowmListReminderTodo = count
+      let g:QFixHowmListReminderTodo = v:count
     endif
   endif
   if exists('*QFixHowmInit') && QFixHowmInit()
@@ -497,7 +497,7 @@ function! s:QFixHowmListReminder_(mode,...)
     let l:SearchFile = fnamemodify(g:QFixHowm_ScheduleSearchFile, ':t')
   endif
 
-  if s:reminder_cache == 0 || count
+  if s:reminder_cache == 0 || v:count
     redraw | echo 'QFixHowm : making holiday...'
     if g:QFixHowm_HolidayFile == ''
       let files = split(glob(l:howm_dir.'/**/Sche-Hd-0000-00-00-000000.*'), '\n')
@@ -1664,7 +1664,7 @@ endfunction
 "繰り返し予定展開
 function! QFixHowmGenerateRepeatDate()
   let save_cursor = getpos('.')
-  let loop = count
+  let loop = v:count
   if loop == 0
     let loop = 1
   endif

--- a/autoload/qfixmemo.vim
+++ b/autoload/qfixmemo.vim
@@ -935,8 +935,8 @@ function! qfixmemo#EditNew()
     return
   endif
   let file = g:qfixmemo_filename
-  if count
-    exe 'let file = g:qfixmemo_filename'.count
+  if v:count
+    exe 'let file = g:qfixmemo_filename'.v:count
   endif
   call qfixmemo#Edit(file)
 endfunction
@@ -948,8 +948,8 @@ function! qfixmemo#EditInput()
     return
   endif
   let fname = g:qfixmemo_misc_file
-  if count
-    exe 'let fname = g:qfixmemo_misc_file'.count
+  if v:count
+    exe 'let fname = g:qfixmemo_misc_file'.v:count
   endif
   let fname = substitute(fname, '[/\\]\+', '/', 'g')
   while 1
@@ -982,9 +982,9 @@ function! qfixmemo#Quickmemo(...)
     let s:qfixmemo_quickmemo = g:qfixmemo_quickmemo
   endif
   let file = s:qfixmemo_quickmemo
-  let num = a:0 ? a:1 : count
-  if count
-    exe 'let file = g:qfixmemo_quickmemo'.count
+  let num = a:0 ? a:1 : v:count
+  if v:count
+    exe 'let file = g:qfixmemo_quickmemo'.v:count
     let s:qfixmemo_quickmemo = file
   endif
   if fnamemodify(file, ':e') == ''
@@ -1301,8 +1301,8 @@ function! qfixmemo#ListMru()
     redraw | echo 'QFixMemo : QFixMRU is not executable.'
     return
   endif
-  if count
-    let g:QFixMRU_Entries = count
+  if v:count
+    let g:QFixMRU_Entries = v:count
   endif
   redraw | echo 'QFixMemo : Read MRU...'
   call QFixMRU(g:qfixmemo_dir, '/:dir')
@@ -1313,8 +1313,8 @@ function! qfixmemo#ListRecent()
   if qfixmemo#Init()
     return
   endif
-  if count
-    let g:qfixmemo_recentdays = count
+  if v:count
+    let g:qfixmemo_recentdays = v:count
   endif
   let title = QFixMRUGetTitleGrepRegxp(g:qfixmemo_ext)
   let qflist = qfixlist#search(title, g:qfixmemo_dir, 'mtime', g:qfixmemo_recentdays, g:qfixmemo_fileencoding, '**/*')
@@ -1327,8 +1327,8 @@ function! qfixmemo#ListRecentTimeStamp(...)
     return
   endif
   call qfixlist#Init()
-  if count
-    let g:qfixmemo_recentdays = count
+  if v:count
+    let g:qfixmemo_recentdays = v:count
   endif
   let days = g:qfixmemo_recentdays
 
@@ -1685,8 +1685,8 @@ function! qfixmemo#Calendar(...)
     return
   endif
   silent! call howm_calendar#init()
-  if count
-    let g:qfixmemo_calendar_count = count
+  if v:count
+    let g:qfixmemo_calendar_count = v:count
   endif
   call QFixMemoCalendar(g:qfixmemo_calendar_wincmd, '__Calendar__', g:qfixmemo_calendar_count)
 endfunction
@@ -1721,8 +1721,8 @@ function! qfixmemo#RandomWalk(file, ...)
     let s:rwalk = s:randomReadFile(file, dir)
   endif
   let columns = g:qfixmemo_random_columns
-  if count
-    let g:qfixmemo_random_columns = count
+  if v:count
+    let g:qfixmemo_random_columns = v:count
   endif
   if &ft == 'qf' && winheight(0) > columns
     let columns = winheight(0)
@@ -2079,7 +2079,7 @@ function! qfixmemo#SubMenu(...)
   if exists('g:qfixmemo_submenu_dir')
     let basedir = g:qfixmemo_submenu_dir
   endif
-  let l:count = a:0 && a:1 ? a:1 : count
+  let l:count = a:0 && a:1 ? a:1 : v:count
   let file = s:submenu_mkdir(basedir)
   let bufnum = bufnr(file)
   let winnum = bufwinnr(file)
@@ -3156,7 +3156,7 @@ function qfixmemo#WildcardChapter(...) range
   call qfixmemo#Init()
   let firstline = a:firstline
   let lastline = a:lastline
-  if a:0 == 0 && count == 0
+  if a:0 == 0 && v:count == 0
     let firstline = 1
     let lastline = line('$')
   endif

--- a/autoload/qfixmru.vim
+++ b/autoload/qfixmru.vim
@@ -159,8 +159,8 @@ function! QFixMRU(...)
   let dirmode = g:QFixMRU_DirMode
   let basedir = expand('%:p:h')
   let entries = g:QFixMRU_Entries
-  if count
-    let entries = count
+  if v:count
+    let entries = v:count
   endif
   for index in range (1, a:0)
     if a:{index} == '^\s*$'

--- a/autoload/qfixwin.vim
+++ b/autoload/qfixwin.vim
@@ -615,10 +615,10 @@ endfunction
 function! s:BeforeJump()
   call QFixPclose()
   call QFixCR('before')
-  if count == 0
+  if v:count == 0
     return
   endif
-  call cursor(count, 1)
+  call cursor(v:count, 1)
 endfunction
 
 if !exists('*QFixCR')
@@ -1064,8 +1064,8 @@ function! s:ResizeOnQFix(...)
     return
   endif
   let size = g:QFix_HeightDefault
-  if count > 1
-    let size = count
+  if v:count > 1
+    let size = v:count
   endif
   call s:QFixResize(size)
 endfunction
@@ -1684,8 +1684,8 @@ endif
 
 function! s:MyGrepWriteResult(mode, file) range
   let file = expand(g:MyGrep_Resultfile)
-  if count
-    let file = substitute(file, '\(\.[^.]\+$\)', count.'\1', '')
+  if v:count
+    let file = substitute(file, '\(\.[^.]\+$\)', v:count.'\1', '')
   endif
   if a:file != ''
     let file = a:file
@@ -1722,8 +1722,8 @@ function! s:MyGrepReadResult(readflag, ...)
   if a:0 > 1
     let file = a:2
   endif
-  if count
-    let file = substitute(file, '\(\.[^.]\+$\)', count.'\1', '')
+  if v:count
+    let file = substitute(file, '\(\.[^.]\+$\)', v:count.'\1', '')
   endif
   if a:readflag
     let s:resulttime = 0


### PR DESCRIPTION
neovim 0.2.2 で qfixhowm を使っているのですが、最近更新したエントリ一覧を表示させると(ListRecent)、以下のようなエラーが出ます:

```
function qfixmemo#ListRecent の処理中にエラーが検出されました:
行    4:
E121: Undefined variable: count
E15: 無効な式です: count
```

Vim の仕様では、変数 count のスコープを省略した場合 v:count が使われるとのことですが、neovim 0.2.2 では仕様が変わっているのかもしれません。実際、コマンドラインで

```
:echo count
```

とした場合、Vim 8.0.1144 では 0 が表示されますが、neovim 0.2.2 では未定義変数エラーになります。
追記: やはり仕様変更で count が v:count の別名としては扱われなくなったようです: https://github.com/neovim/neovim/wiki/Following-HEAD#20171118

スコープなし変数 count を全て v:count に置換したところ neovim 0.2.2 でも問題なく動くようになったので、よろしければパッチを取り込んでいただけないでしょうか。
(Vim script には詳しくないので、何かしらの理由があってスコープなしになっているのでしたら申し訳ありません)

qfixgrep の方にも同様の pull request を送りました: https://github.com/fuenor/qfixgrep/pull/3