### PR TITLE
ｓg:qfixmemo_dirの設定次第でqfixmemo#RenameAll()が失敗する可能性があるので対処しました

### DIFF
--- a/autoload/qfixmemo.vim
+++ b/autoload/qfixmemo.vim
@@ -1653,7 +1653,10 @@ function! qfixmemo#RenameAll()
       call add(glist, d)
       continue
     endif
-    call rename(from, to)
+    if rename(from, to) ! 0
+      call add(glist, d)
+      continue
+    endif
   endfor
   close!
   call qfixlist#open(glist, g:qfixmemo_dir)

--- a/autoload/qfixmemo.vim
+++ b/autoload/qfixmemo.vim
@@ -1638,6 +1638,7 @@ function! qfixmemo#RenameAll()
   for n in range(1, line('$'))
     let str = getline(n)
     let from = g:qfixmemo_dir.'/'.substitute(str, '|.*$', '', '')
+    let from = expand(from)
     let form = substitute(from, '\\', '/', 'g')
     let to   = substitute(str, '^[^|]\+|[^|]|', '', '')
     let res = {'filename': from, 'lnum': 1, 'text': to}


### PR DESCRIPTION
qfixmemo#RenameAll内のrename関数が失敗する可能性があったので対処しました
g:qfixmemo_dirを未設定の場合など、`~`が含まれる場合にrename関数の実行が失敗してしまうので
あらかじめexpand関数で展開しておきました
また、rename関数が失敗したときにglistに追加して失敗したことが分かるようにしました